### PR TITLE
chore: cookies_*.json を .gitignore の対象に含める

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,5 +210,5 @@ __marimo__/
 CLAUDE.md
 
 # Scraper secrets and output
-cookies.json
+cookies*.json
 output_*.json


### PR DESCRIPTION
## Summary
- `cookies.json` のみ除外していたパターンを `cookies*.json` に拡張し、`cookies_ぴにこ.json` のようなサフィックス付きファイルも管理対象外にする

## 原因
`.gitignore` に `cookies.json` と完全一致のパターンしか記載しておらず、ファイル名にサフィックスが付いた場合に除外されなかった

## 変更内容
| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| `.gitignore` のパターン | `cookies.json` | `cookies*.json` |

## Test plan
- [x] `git status` で `cookies_*.json` が untracked ではなく ignored になることを確認