### PR TITLE
fix: 同一機体使用時にスコアが上側プレイヤーの値で上書きされるバグを修正

### DIFF
--- a/scraper/parsers/match.py
+++ b/scraper/parsers/match.py
@@ -102,10 +102,12 @@ def _parse_score_box(box):
 
 def _merge_scores(team, score_list):
     """Merge score data into team players matched by icon_url."""
+    used = set()
     for player in team['players']:
-        for entry in score_list:
-            if entry['icon_url'] == player['icon_url']:
+        for i, entry in enumerate(score_list):
+            if i not in used and entry['icon_url'] == player['icon_url']:
                 player.update({k: v for k, v in entry.items() if k != 'icon_url'})
+                used.add(i)
                 break
 
 


### PR DESCRIPTION
## Summary
- チーム内で2人が同じ機体を使用した試合において、下側プレイヤーのスコア（score, kills, deaths 等）が上側プレイヤーの値でコピーされていた問題を修正

## 原因
`_merge_scores()` が `icon_url`（機体アイコン）でスコアをマッチングしていた。同一機体の場合は両プレイヤーが同じ `icon_url` を持つため、ループが常に先頭エントリ（上側プレイヤーのスコア）を返し、下側プレイヤーにも同じスコアが割り当てられていた。

## 変更内容
| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| `scraper/parsers/match.py` `_merge_scores()` | 消費済みエントリを管理しない | `used` セットで消費済みエントリを管理し再利用を防ぐ |

## Test plan
- [ ] 同一機体を使った2人のプレイヤーがいる試合をスクレイプし、それぞれ異なるスコアが出力されることを確認

Closes #12