### PR TITLE
feat: GitHub Actions ワークフローによるスクレイパー自動実行

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           RESPONSE=$(curl -sf -w "\n%{http_code}" \
             -X POST \
-            -H "Authorization: Bearer ${{ secrets.TIMESTAMP_API_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.VSMOBILE_API_TOKEN }}" \
             -H "Content-Type: application/json" \
             -d @output/result.json \
             "${{ secrets.VSMOBILE_API_URL }}/api/events/${{ inputs.event_id }}/stats" 2>&1 || true)
@@ -75,7 +75,7 @@ jobs:
 
           curl -sf \
             -X POST \
-            -H "Authorization: Bearer ${{ secrets.TIMESTAMP_API_TOKEN }}" \
+            -H "Authorization: Bearer ${{ secrets.VSMOBILE_API_TOKEN }}" \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD" \
             "${{ secrets.VSMOBILE_API_URL }}/api/events/${{ inputs.event_id }}/notify_failure" || true

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ python scrape.py --cookies-all
 | シークレット名 | 内容 |
 |---------------|------|
 | `COOKIES_ALL` | `cookies/all.json` の中身をそのまま貼り付けた JSON 文字列 |
-| `TIMESTAMP_API_TOKEN` | vsmobile-kgy の API Bearer トークン |
+| `VSMOBILE_API_TOKEN` | vsmobile-kgy の API Bearer トークン |
 | `VSMOBILE_API_URL` | vsmobile-kgy のベース URL（例: `https://example.com`、末尾スラッシュなし） |
 
 #### `COOKIES_ALL` の形式


### PR DESCRIPTION
## Summary

- `.github/workflows/scrape.yml` を新規作成（`workflow_dispatch` トリガー）
- 入力パラメータ: `event_id`（vsmobile-kgy のイベント ID）
- Cookie は `COOKIES_ALL` シークレットから `cookies/all.json` に書き出して実行
- 成功時: スクレイパー出力 JSON を `POST /api/events/{id}/stats` に送信
- 失敗時: `POST /api/events/{id}/notify_failure` にエラーメッセージ（Actions ログ URL 付き）を送信
- README にワークフローの使い方・必要なシークレットを追記

## 必要なシークレット

| シークレット名 | 内容 |
|---|---|
| `COOKIES_ALL` | `cookies/all.json` の内容（JSON 文字列） |
| `TIMESTAMP_API_TOKEN` | vsmobile-kgy の Bearer トークン |
| `VSMOBILE_API_URL` | vsmobile-kgy のベース URL |

## Test plan

- [ ] GitHub Actions の手動実行画面で `event_id` 入力欄が表示されることを確認
- [ ] 正常系: 有効な Cookie・正しい `event_id` で実行し、API に 200 が返ることを確認
- [ ] 異常系（Cookie 期限切れ）: スクレイパーが失敗し、notify_failure が呼ばれることを確認
- [ ] 異常系（不正 event_id）: API が 404 を返し、notify_failure が呼ばれることを確認

Closes #6