### PR TITLE
chore: v0.4.0 リリース

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -64,7 +64,7 @@ jobs:
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
           if [ "${{ steps.scrape.outcome }}" = "failure" ]; then
-            ERROR_MSG="スクレイパーの実行に失敗しました（Cookie が期限切れの可能性があります）。ログ: $RUN_URL"
+            ERROR_MSG="スクレイパーの実行に失敗しました（全ユーザーの Cookie が期限切れの可能性があります）。ログ: $RUN_URL"
           elif [ "${{ steps.upload.outcome }}" = "failure" ]; then
             ERROR_MSG="API への送信に失敗しました。ログ: $RUN_URL"
           else

--- a/README.md
+++ b/README.md
@@ -76,64 +76,97 @@ python scrape.py --cookies-all
 
 `--cookies-all` モードでは、全ユーザーの結果を `match_ts` キーで重複排除してマージする。出力ファイル名のデフォルトは `output/all_{YYYYMMDD}.json`。
 
-いずれかのユーザーの Cookie が期限切れだった場合はそのユーザーをスキップして処理を継続し、最後に警告を表示して終了コード `1` で終了する。
+一部ユーザーの Cookie が期限切れだった場合はそのユーザーをスキップして処理を継続し、最後に警告を表示する。期限切れユーザー名は出力 JSON の `expired_users` フィールドに含まれる。全ユーザーの Cookie が期限切れだった場合のみ終了コード `1` で終了する。
+
+### Cookie の疎通確認
+
+スクレイピング前に Cookie が有効かどうかだけを確認したい場合（対戦履歴がない状態での確認など）は `check_auth.py` を使う。
+
+```bash
+# 単一ユーザーの確認（cookies/cookies.json）
+python check_auth.py
+
+# Cookie ファイルを指定
+python check_auth.py --cookies cookies/alice.json
+
+# 全ユーザーを一括確認（cookies/all.json）
+python check_auth.py --all
+```
+
+出力例:
+```
+[CHECK] ぱぴこ ... OK
+[CHECK] りーん ... EXPIRED
+
+Result: 1 OK / 1 EXPIRED
+```
+
+全員有効なら終了コード `0`、1人でも期限切れがあれば終了コード `1` で終了する。
 
 ## 出力形式
 
 出力ファイル名（デフォルト）: `output/{プレイヤー名}_{YYYYMMDD}.json`
 
-試合データのリスト（`match_ts` 昇順）を JSON で出力する。
+試合データのリスト（`match_ts` 昇順）と期限切れ Cookie ユーザー一覧を JSON で出力する。
 
 ```json
-[
-  {
-    "match_ts": "1739500000",
-    "time": "14:32",
-    "game_date": "2026/02/14(土)",
-    "shop_name": "〇〇ゲームセンター",
-    "team_a": {
-      "team_name": "チームA",
-      "result": "win",
-      "players": [
-        {
-          "name": "プレイヤー1",
-          "player_param": "AbCdEfGh...",
-          "icon_url": "https://example.com/icon.png",
-          "mastery": "blue5",
-          "prefecture": "東京都",
-          "is_self": true,
-          "match_rank": 1,
-          "score": 12000,
-          "kills": 3,
-          "deaths": 1,
-          "damage_dealt": 8500,
-          "damage_received": 3200,
-          "exburst_damage": 1500
-        }
-      ]
-    },
-    "team_b": { "...": "..." },
-    "timeline_raw": {
-      "groups": {
-        "team1-1": "https://example.com/unit_icon.png"
+{
+  "matches": [
+    {
+      "match_ts": "1739500000",
+      "time": "14:32",
+      "game_date": "2026/02/14(土)",
+      "shop_name": "〇〇ゲームセンター",
+      "team_a": {
+        "team_name": "チームA",
+        "result": "win",
+        "players": [
+          {
+            "name": "プレイヤー1",
+            "player_param": "AbCdEfGh...",
+            "icon_url": "https://example.com/icon.png",
+            "mastery": "blue5",
+            "prefecture": "東京都",
+            "is_self": true,
+            "match_rank": 1,
+            "score": 12000,
+            "kills": 3,
+            "deaths": 1,
+            "damage_dealt": 8500,
+            "damage_received": 3200,
+            "exburst_damage": 1500
+          }
+        ]
       },
-      "events": [
-        {
-          "group": "team1-1",
-          "start_cs": 1500,
-          "start_str": "0:15.00",
-          "end_cs": 4200,
-          "end_str": "0:42.00",
-          "class_name": "exbst-s",
-          "is_point": false
-        }
-      ],
-      "game_end_cs": 36000,
-      "game_end_str": "6:00.00"
+      "team_b": { "...": "..." },
+      "timeline_raw": {
+        "groups": {
+          "team1-1": "https://example.com/unit_icon.png"
+        },
+        "events": [
+          {
+            "group": "team1-1",
+            "start_cs": 1500,
+            "start_str": "0:15.00",
+            "end_cs": 4200,
+            "end_str": "0:42.00",
+            "class_name": "exbst-s",
+            "is_point": false
+          }
+        ],
+        "game_end_cs": 36000,
+        "game_end_str": "6:00.00"
+      }
     }
-  }
-]
+  ],
+  "expired_users": ["りーん"]
+}
 ```
+
+| フィールド | 説明 |
+|-----------|------|
+| `matches` | 試合データのリスト（`match_ts` 昇順） |
+| `expired_users` | Cookie が期限切れだったユーザー名のリスト。全員有効なら `[]` |
 
 ### フィールド説明
 
@@ -191,12 +224,12 @@ python scrape.py --cookies-all
 
 #### `COOKIES_ALL` の形式
 
-`python build_cookies.py` で生成される `cookies/all.json` の内容をそのまま貼り付ける。
+`python build_cookies.py` で生成される `cookies/all.json` の内容をそのまま貼り付ける。`build_cookies.py` は各ユーザーの `laravel_session` のみを抽出してマージする。
 
 ```json
 {
-  "ぱぴこ": [{ "name": "_session_id", "value": "...", "domain": "web.vsmobile.jp" }],
-  "てるしき": [{ "name": "_session_id", "value": "...", "domain": "web.vsmobile.jp" }]
+  "ぱぴこ": [{ "name": "laravel_session", "value": "...", "domain": "web.vsmobile.jp" }],
+  "てるしき": [{ "name": "laravel_session", "value": "...", "domain": "web.vsmobile.jp" }]
 }
 ```
 
@@ -211,7 +244,8 @@ python scrape.py --cookies-all
 
 | 状況 | 挙動 |
 |------|------|
-| Cookie が期限切れ | スクレイパーが終了コード 1 で終了し、`POST /api/events/{id}/notify_failure` にエラーメッセージを送信 |
+| 一部ユーザーの Cookie が期限切れ | 有効なユーザー分のデータを取得し、`expired_users` に期限切れユーザー名を含めて API に送信 |
+| 全ユーザーの Cookie が期限切れ | スクレイパーが終了コード 1 で終了し、`POST /api/events/{id}/notify_failure` にエラーメッセージを送信 |
 | API 送信失敗（4xx/5xx） | `POST /api/events/{id}/notify_failure` にエラーメッセージを送信 |
 | その他のエラー | 同上 |
 

--- a/build_cookies.py
+++ b/build_cookies.py
@@ -9,6 +9,17 @@ import sys
 COOKIES_DIR = 'cookies'
 OUTPUT = os.path.join(COOKIES_DIR, 'all.json')
 
+SESSION_DOMAIN = 'web.vsmobile.jp'
+SESSION_NAME = 'laravel_session'
+
+
+def _extract_session_cookie(cookies):
+    """Extract only the laravel_session cookie from a cookie list."""
+    for c in cookies:
+        if c.get('name') == SESSION_NAME and SESSION_DOMAIN in c.get('domain', ''):
+            return [{'name': c['name'], 'value': c['value'], 'domain': c['domain']}]
+    return []
+
 
 def main():
     pattern = os.path.join(COOKIES_DIR, '*.json')
@@ -22,8 +33,12 @@ def main():
         name = os.path.splitext(os.path.basename(path))[0]
         with open(path, encoding='utf-8') as f:
             cookies = json.load(f)
-        all_cookies[name] = cookies
-        print(f'  Loaded: {path!r}  ({len(cookies)} cookies) → user={name!r}')
+        session_cookie = _extract_session_cookie(cookies)
+        if not session_cookie:
+            print(f'  [WARN] {path!r}: laravel_session not found, skipping', file=sys.stderr)
+            continue
+        all_cookies[name] = session_cookie
+        print(f'  Loaded: {path!r} → user={name!r}')
 
     with open(OUTPUT, 'w', encoding='utf-8') as f:
         json.dump(all_cookies, f, ensure_ascii=False, indent=2)

--- a/check_auth.py
+++ b/check_auth.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Check whether cookies are valid by verifying no auth redirect occurs."""
+
+import argparse
+import json
+import sys
+
+from scraper.session import AuthRedirectError, build_session, check_redirect
+
+BASE_URL = 'https://web.vsmobile.jp/exvs2ib'
+SHOP_URL = f'{BASE_URL}/results/shop'
+
+
+def _check_single(name, cookies):
+    """Return True if the session is valid, False if expired."""
+    session = build_session(cookies)
+    resp = session.get(SHOP_URL)
+    try:
+        check_redirect(resp)
+        return True
+    except AuthRedirectError:
+        return False
+
+
+def _run_single(cookies_path):
+    with open(cookies_path, encoding='utf-8') as f:
+        cookies = json.load(f)
+
+    print(f'[CHECK] {cookies_path} ... ', end='', flush=True)
+    ok = _check_single(cookies_path, cookies)
+    print('OK' if ok else f'EXPIRED')
+    return ok
+
+
+def _run_all(cookies_all_path):
+    with open(cookies_all_path, encoding='utf-8') as f:
+        all_cookies = json.load(f)
+
+    results = {}
+    for name, cookies in all_cookies.items():
+        print(f'[CHECK] {name} ... ', end='', flush=True)
+        ok = _check_single(name, cookies)
+        results[name] = ok
+        print('OK' if ok else 'EXPIRED')
+
+    ok_count = sum(1 for v in results.values() if v)
+    expired_count = len(results) - ok_count
+    print(f'\nResult: {ok_count} OK / {expired_count} EXPIRED')
+    return expired_count == 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Check VS.Mobile cookie validity')
+    parser.add_argument('--cookies', default='cookies/cookies.json', help='Path to cookies JSON file')
+    parser.add_argument(
+        '--all',
+        nargs='?',
+        const='cookies/all.json',
+        metavar='PATH',
+        help='Path to merged cookies JSON (default: cookies/all.json); check all users',
+    )
+    args = parser.parse_args()
+
+    if args.all is not None:
+        ok = _run_all(args.all)
+    else:
+        ok = _run_single(args.cookies)
+
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == '__main__':
+    main()

--- a/scrape.py
+++ b/scrape.py
@@ -99,8 +99,9 @@ def _run_single(cookies_path, output_path):
     results.sort(key=lambda r: r['match_ts'])
     out = output_path or f'output/{self_name}_{game_date_str}.json'
     os.makedirs(os.path.dirname(out) or '.', exist_ok=True)
+    payload = {'matches': results, 'expired_users': []}
     with open(out, 'w', encoding='utf-8') as f:
-        json.dump(results, f, ensure_ascii=False, indent=2)
+        json.dump(payload, f, ensure_ascii=False, indent=2)
     print(f'Done. {len(results)} matches written to {out}')
 
 
@@ -141,13 +142,13 @@ def _run_all(cookies_all_path, output_path):
     all_results.sort(key=lambda r: r['match_ts'])
     out = output_path or f'output/all_{game_date_str}.json'
     os.makedirs(os.path.dirname(out) or '.', exist_ok=True)
+    payload = {'matches': all_results, 'expired_users': failed}
     with open(out, 'w', encoding='utf-8') as f:
-        json.dump(all_results, f, ensure_ascii=False, indent=2)
+        json.dump(payload, f, ensure_ascii=False, indent=2)
     print(f'\nDone. {len(all_results)} unique matches written to {out}')
 
     if failed:
         print(f'[WARN] Cookie expired for: {", ".join(failed)}', file=sys.stderr)
-        sys.exit(1)
 
 
 def main():


### PR DESCRIPTION
## Summary
release/v0.4.0 を main にマージするリリースPRです。

## 主な変更
- Cookie の有効性を確認する疎通確認スクリプト（`check_auth.py`）を追加
- スクレイプ結果の出力フォーマットを変更し、期限切れ Cookie ユーザーを `expired_users` フィールドで通知
- `build_cookies.py` で `laravel_session` のみをフィルタリングしてマージするよう改善
- README を最新の仕様に更新

## 関連Issue・PR
- #17 / PR #19
- #18 / PR #20
- #21 / PR #22